### PR TITLE
Fix int16

### DIFF
--- a/src/FSharp.UMX.fs
+++ b/src/FSharp.UMX.fs
@@ -9,7 +9,6 @@ open System
 
 [<MeasureAnnotatedAbbreviation>] type bool<[<Measure>] 'm> = bool
 [<MeasureAnnotatedAbbreviation>] type byte<[<Measure>] 'm> = byte
-[<MeasureAnnotatedAbbreviation>] type int16<[<Measure>] 'm> = int16
 [<MeasureAnnotatedAbbreviation>] type uint64<[<Measure>] 'm> = uint64
 [<MeasureAnnotatedAbbreviation>] type Guid<[<Measure>] 'm> = Guid
 [<MeasureAnnotatedAbbreviation>] type string<[<Measure>] 'm> = string


### PR DESCRIPTION
This line appears to cause problems that I don't quite understand when tagging an `int16` with `%` and the expected type is an alias of `int16` with a measure. Perhaps it's because short supports units of measure natively?

```fsharp
[<Measure>]
type columnDefinitionId
type ColumnDefinitionId = int<columnDefinitionId>

[<Measure>]
type order
type Order = int16<order>

type ColumnDefinition = {
    Id: ColumnDefinitionId
    Order: Order }

let x = { Id = %1; Order = %2s }
//This expression was expected to have type  'Order'  but here has type  'int16<'u>'
```