### PR TITLE
Added DateOnly & TimeOnly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,6 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.400
+        dotnet-version: 6.0.402
     - name: Build
       run: dotnet test -c Release

--- a/src/FSharp.UMX.fs
+++ b/src/FSharp.UMX.fs
@@ -15,7 +15,7 @@ open System
 [<MeasureAnnotatedAbbreviation>] type TimeSpan<[<Measure>] 'm> = TimeSpan
 [<MeasureAnnotatedAbbreviation>] type DateTime<[<Measure>] 'm> = DateTime
 [<MeasureAnnotatedAbbreviation>] type DateTimeOffset<[<Measure>] 'm> = DateTimeOffset
-#if NET6_0
+#if NET6_0_OR_GREATER
 [<MeasureAnnotatedAbbreviation>] type DateOnly<[<Measure>] 'm> = DateOnly
 [<MeasureAnnotatedAbbreviation>] type TimeOnly<[<Measure>] 'm> = TimeOnly
 #endif
@@ -44,7 +44,7 @@ type UMX =
     static member inline tag<[<Measure>]'m> (x : TimeSpan) : TimeSpan<'m> = Unsafe.cast x
     static member inline tag<[<Measure>]'m> (x : DateTime) : DateTime<'m> = Unsafe.cast x
     static member inline tag<[<Measure>]'m> (x : DateTimeOffset) : DateTimeOffset<'m> = Unsafe.cast x
-#if NET6_0
+#if NET6_0_OR_GREATER
     static member inline tag<[<Measure>]'m> (x : DateOnly) : DateOnly<'m> = Unsafe.cast x
     static member inline tag<[<Measure>]'m> (x : TimeOnly) : TimeOnly<'m> = Unsafe.cast x
 #endif
@@ -63,7 +63,7 @@ type UMX =
     static member inline untag<[<Measure>]'m> (x : TimeSpan<'m>) : TimeSpan = Unsafe.cast x
     static member inline untag<[<Measure>]'m> (x : DateTime<'m>) : DateTime = Unsafe.cast x
     static member inline untag<[<Measure>]'m> (x : DateTimeOffset<'m>) : DateTimeOffset = Unsafe.cast x
-#if NET6_0
+#if NET6_0_OR_GREATER
     static member inline untag<[<Measure>]'m> (x : DateOnly<'m>) : DateOnly = Unsafe.cast x
     static member inline untag<[<Measure>]'m> (x : TimeOnly<'m>) : TimeOnly = Unsafe.cast x
 #endif
@@ -82,7 +82,7 @@ type UMX =
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : TimeSpan<'m1>) : TimeSpan<'m2> = Unsafe.cast x
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : DateTime<'m1>) : DateTime<'m2> = Unsafe.cast x
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : DateTimeOffset<'m1>) : DateTimeOffset<'m2> = Unsafe.cast x
-#if NET6_0
+#if NET6_0_OR_GREATER
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : DateOnly<'m1>) : DateOnly<'m2> = Unsafe.cast x
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : TimeOnly<'m1>) : TimeOnly<'m2> = Unsafe.cast x
 #endif

--- a/src/FSharp.UMX.fs
+++ b/src/FSharp.UMX.fs
@@ -15,6 +15,10 @@ open System
 [<MeasureAnnotatedAbbreviation>] type TimeSpan<[<Measure>] 'm> = TimeSpan
 [<MeasureAnnotatedAbbreviation>] type DateTime<[<Measure>] 'm> = DateTime
 [<MeasureAnnotatedAbbreviation>] type DateTimeOffset<[<Measure>] 'm> = DateTimeOffset
+#if NET6_0
+[<MeasureAnnotatedAbbreviation>] type DateOnly<[<Measure>] 'm> = DateOnly
+[<MeasureAnnotatedAbbreviation>] type TimeOnly<[<Measure>] 'm> = TimeOnly
+#endif
 
 module private Unsafe =
     let inline cast<'a, 'b> (a : 'a) : 'b =
@@ -40,6 +44,10 @@ type UMX =
     static member inline tag<[<Measure>]'m> (x : TimeSpan) : TimeSpan<'m> = Unsafe.cast x
     static member inline tag<[<Measure>]'m> (x : DateTime) : DateTime<'m> = Unsafe.cast x
     static member inline tag<[<Measure>]'m> (x : DateTimeOffset) : DateTimeOffset<'m> = Unsafe.cast x
+#if NET6_0
+    static member inline tag<[<Measure>]'m> (x : DateOnly) : DateOnly<'m> = Unsafe.cast x
+    static member inline tag<[<Measure>]'m> (x : TimeOnly) : TimeOnly<'m> = Unsafe.cast x
+#endif
 
     static member inline untag<[<Measure>]'m> (x : bool<'m>) : bool = Unsafe.cast x
     static member inline untag<[<Measure>]'m> (x : byte<'m>) : byte = Unsafe.cast x
@@ -55,6 +63,10 @@ type UMX =
     static member inline untag<[<Measure>]'m> (x : TimeSpan<'m>) : TimeSpan = Unsafe.cast x
     static member inline untag<[<Measure>]'m> (x : DateTime<'m>) : DateTime = Unsafe.cast x
     static member inline untag<[<Measure>]'m> (x : DateTimeOffset<'m>) : DateTimeOffset = Unsafe.cast x
+#if NET6_0
+    static member inline untag<[<Measure>]'m> (x : DateOnly<'m>) : DateOnly = Unsafe.cast x
+    static member inline untag<[<Measure>]'m> (x : TimeOnly<'m>) : TimeOnly = Unsafe.cast x
+#endif
 
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : bool<'m1>) : bool<'m2> = Unsafe.cast x
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : byte<'m1>) : byte<'m2> = Unsafe.cast x
@@ -70,6 +82,10 @@ type UMX =
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : TimeSpan<'m1>) : TimeSpan<'m2> = Unsafe.cast x
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : DateTime<'m1>) : DateTime<'m2> = Unsafe.cast x
     static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : DateTimeOffset<'m1>) : DateTimeOffset<'m2> = Unsafe.cast x
+#if NET6_0
+    static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : DateOnly<'m1>) : DateOnly<'m2> = Unsafe.cast x
+    static member inline cast<[<Measure>]'m1, [<Measure>]'m2> (x : TimeOnly<'m1>) : TimeOnly<'m2> = Unsafe.cast x
+#endif
 
 
 [<AutoOpen>]

--- a/src/FSharp.UMX.fsproj
+++ b/src/FSharp.UMX.fsproj
@@ -10,13 +10,12 @@
 
     <Version>1.0.0</Version>
     <PackageVersion>1.0.0</PackageVersion>
-
-    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningLevel>5</WarningLevel>
 
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FSharp.UMX.Tests.fs
+++ b/tests/FSharp.UMX.Tests.fs
@@ -35,6 +35,9 @@ let ``Simple unit of measure conversions with cast operator``() =
     let b : byte<foo> = % 1uy
     let s : int16<foo> = % 1s
     let f : float32<foo>  = % 10.0f
+    let d : DateTime<foo> = % DateTime.Now
+    let don : DateOnly<foo> = % DateOnly.FromDateTime(DateTime.Now)
+    let ton : TimeOnly<foo> = % TimeOnly.FromDateTime(DateTime.Now)
     ()
 
 [<Fact>]
@@ -45,7 +48,10 @@ let ``Simple unit of measure conversions with UMX.tag function``() =
     let w = UMX.tag<foo> (sprintf "%O %s %d" %x %y %z) 
     let b = UMX.tag<foo> (1uy)                         
     let s = UMX.tag<foo> (1s)                         
-    let f = UMX.tag<foo>  (10.0f)
+    let f = UMX.tag<foo> (10.0f)
+    let d = UMX.tag<foo> DateTime.Now
+    let don = UMX.tag<foo> (DateOnly.FromDateTime(DateTime.Now))
+    let ton = UMX.tag<foo> (TimeOnly.FromDateTime(DateTime.Now))
     ()
 
 [<Fact>]

--- a/tests/FSharp.UMX.Tests.fsproj
+++ b/tests/FSharp.UMX.Tests.fsproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`DateOnly` and `TimeOnly` were added in .NET 6. Adding support in the code was pretty straight forward.

Where I'm not sure is if there are any additional steps for Fable/publishing to Nuget which need to be done or if this would work out of the box. Happy if anyone of the maintainers has any input on this.